### PR TITLE
Поправлен баг со скрытой кнопкой оплаты на iOS 10

### DIFF
--- a/YandexCheckoutPayments.podspec
+++ b/YandexCheckoutPayments.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name      = 'YandexCheckoutPayments'
-  s.version   = '1.3.3'
+  s.version   = '1.3.4'
   s.homepage  = 'https://github.com/yandex-money/yandex-checkout-payments-swift'
   s.license   = {
     :type => "MIT",

--- a/YandexCheckoutPayments/Modules/Tokenization/View/TokenizationViewController.swift
+++ b/YandexCheckoutPayments/Modules/Tokenization/View/TokenizationViewController.swift
@@ -448,12 +448,12 @@ class TokenizationViewController: UIViewController {
         modules.append(vc)
 
         addChildViewController(modalTemplate)
-        modalTemplate.beginAppearanceTransition(true, animated: true)
         modalTemplate.view.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(modalTemplate.view)
 
         modalTemplate.addChildViewController(vc)
         modalTemplate.setContentView(vc.view)
+        modalTemplate.beginAppearanceTransition(true, animated: true)
 
         let startConstraints = [
             modalTemplate.view.leading.constraint(equalTo: view.leading),


### PR DESCRIPTION
На iOS 10 не срабатывает `viewWillAppear` на экране проведения оплаты из-за неверного вызова`modalTemplate.beginAppearanceTransition `